### PR TITLE
updated next to 12, fix setting router locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "next start -p ${PORT:=3000}"
   },
   "dependencies": {
-    "next": "11.1.0",
+    "next": "^12.1.6",
     "next-i18next": "8.8.0",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,11 +1,14 @@
 import { appWithTranslation } from 'next-i18next'
+import { useRouter } from 'next/router'
 
 const MyApp = ({ Component, pageProps }) => <Component {...pageProps} />
 
 const WrappedApp = appWithTranslation(MyApp)
-
 // because we do not use the i18n feature of next.js
 export default function RouterEmulatedApp ({ ...props }) {
-  props.router.locale = props.router.query.locale
+  const router = useRouter();
+  router.locale = props.router.query.locale
+  
+  props.router = router
   return <WrappedApp {...props} />
 }


### PR DESCRIPTION
As overwriting `props.router.locale` with `props.router.query.locale` throws a `Cannot set property of X which has only a getter` error, a new router object is created instead.